### PR TITLE
fixes + new read behaviour

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -139,10 +139,13 @@ Record.prototype.get = function (name, options) {
     else {
       throw new Error('calling get with strange attributes');
     }
-    assert(_.every(_.map(names, (name) => this.model.fields[name])),
-      'getting bad fields');
-    assert(this.readFields['*'] || _.every(names, (name) => this.readFields[
-      name] === true), 'getting unread fields');
+    var notField = _.filter(names, (name) => _.isUndefined(this.model.fields[
+      name]));
+    assert(_.isEmpty(notField), 'getting bad fields', notField);
+    if (!this.readFields['*']) {
+      var notRead = _.filter(names, (name) => this.readFields[name] !== true);
+      assert(_.isEmpty(notRead), 'getting unread fields', notRead);
+    }
   }
   assert(!_.includes(names, 'id'), 'can not get id');
   assert(_.isEmpty(_.omit(options, ['rpc', 'oc', 'inst', 'parent'])),
@@ -247,10 +250,12 @@ Record.prototype.set = function (name, value, options) {
   });
   var changes = {};
   values = deflat(values);
-  assert(_.every(_.map(values, (v, k) => this.model.fields[k])),
-    'setting bad fields');
-  assert(this.readFields['*'] || _.every(_.map(values, (v, k) => this.readFields[
-    k] === true)), 'setting unread fields');
+  var notField = _.filter(values, (v, k) => _.isUndefined(this.model.fields[k]));
+  assert(_.isEmpty(notField), 'setting bad fields: ', notField);
+  if (!this.readFields['*']) {
+    var notRead = _.filter(values, (v, k) => this.readFields[k] !== true);
+    assert(_.isEmpty(notRead), 'setting bad fields: ', notRead);
+  }
   var l = _.map(values, (v, k) => ({
     name: k,
     field: this.model.fields[k],

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,127 +9,13 @@ var patch = require('./group-underscore');
 var cache = require('./cache');
 var dRec = require('debug')('tryton:model:record');
 var dGrp = require('debug')('tryton:model:group');
-//
-// Utils
-//
-function flatten(obj, paths) {
-  var values = _.map(paths, (path) => _.reduce(path.split('.'), (value, sub) => {
-    if (value) {
-      return value[sub];
-    }
-    else {
-      return value;
-    }
-  }, obj));
-  return _.zipObject(paths, values);
-}
 
-function deflat(obj) {
-  var res = {};
-  _.each(_.keys(obj), (k) => {
-    var i = k.indexOf('.');
-    if (i >= 0) {
-      var key = k.substr(0, i);
-      var sub = k.substr(i + 1);
-      if (!res[key]) {
-        res[key] = {};
-      }
-      res[key][sub] = obj[k];
-      delete obj[k];
-    }
-  });
-  if (_.isEmpty(res)) {
-    return obj;
-  }
-  else {
-    _.each(_.keys(obj), (k) => {
-      if (res[k]) {
-        res[k].id = obj[k];
-        delete obj[k];
-      }
-    });
-    res = _.mapValues(res, (v) => {
-      return deflat(v);
-    });
-    return _.assign(obj, res);
-  }
-}
-
-function instFromId(record, field, value) {
-  if (field.cls === 'record') {
-    assert(_.isNumber(value), 'only ids');
-    return Record(record.session, field.desc.relation, value);
-  }
-  else if (field.cls === 'group') {
-    assert(_.isArray(value) && _.every(value, _.isNumber), 'only ids');
-    return Group(record.session, field.desc.relation, record, field.name)
-      .then((group) => {
-        group.init(value);
-        return group;
-      });
-  }
-  else {
-    throw new Error('bad type value');
-  }
-}
-//
-// Record class
-//
 function Empty() {}
 var empty = new Empty();
 
 function updateCache(oldId, newId) {
   cache.set(this.session, this.model.name, oldId, null);
   cache.set(this.session, this.model.name, newId, this);
-}
-
-function afterRead(name, result) {
-  if (!name) {
-    this.attrs = {};
-    this.changes = {};
-    this.readFields = {
-      '*': true
-    };
-  }
-  else {
-    this.changes = _.omit(this.changes, _.keys(result));
-    _.assign(this.readFields, _.mapValues(result, () => true));
-  }
-}
-
-function parseReadParam(model, name) {
-  var names;
-  if (_.isString(name)) {
-    names = [name];
-  }
-  else if (_.isArray(name)) {
-    names = name;
-  }
-  else {
-    return;
-  }
-  if (names[0][0] === '!') {
-    names = _.map(names, (name) => name.substr(1));
-    names = _.keys(_.omit(model.fields, names));
-  }
-  return names;
-}
-
-function setContext(key, value) {
-  if (_.isNil(key)) {
-    this.context = null;
-  }
-  else {
-    if (!this.context) {
-      this.context = {};
-    }
-    if (_.isString(key)) {
-      this.context[key] = value;
-    }
-    else if (_.isPlainObject(key)) {
-      _.assign(this.context, key);
-    }
-  }
 }
 
 function Record(session, model, id, group) {
@@ -156,27 +42,44 @@ function Record(session, model, id, group) {
 }
 inherits(Record, EventEmitter);
 Record.prototype.detach = function () {
+  dRec('%s: detach', this.model.name);
   cache.set(this.session, this.model.name, this.id, null);
   this.removeListener('mutate', updateCache);
 };
-Record.prototype.resetReadPromise = function () {
-  this.readPromise = false;
-};
-Record.prototype.resetWritePromise = function () {
-  this.writePromise = null;
-};
-Record.prototype.reset = function () {
-  this.resetReadPromise();
-  this.resetWritePromise();
+
+function resetAttrs() {
   this.attrs = {};
   this.changes = {};
   this.readFields = this.id > 0 ? {} : {
     '*': true
   };
+}
+Record.prototype.reset = function () {
+  dRec('%s: reset', this.model.name);
+  this.readPromise = false;
+  this.writePromise = false;
+  resetAttrs.call(this);
 };
 Record.prototype.changed = function () {
   return !_.isEmpty(this.changes);
 };
+
+function setContext(key, value) {
+  if (_.isNil(key)) {
+    this.context = null;
+  }
+  else {
+    if (!this.context) {
+      this.context = {};
+    }
+    if (_.isString(key)) {
+      this.context[key] = value;
+    }
+    else if (_.isPlainObject(key)) {
+      _.assign(this.context, key);
+    }
+  }
+}
 Record.prototype.setContext = function (key, value) {
   dRec('%s: setContext', this.model.name);
   setContext.call(this, key, value);
@@ -190,16 +93,26 @@ Record.prototype.getContext = function () {
   _.assign(result, this.context);
   return result;
 };
-Record.prototype.loadModel = function () {
-  dRec('%s: loadModel', this.model.name);
-  Model(this.session, this.model.name, this.getContext())
-    .then((model) => {
-      this.model = model;
-    });
-};
+
+function instFromId(record, field, value) {
+  if (field.cls === 'record') {
+    assert(_.isNumber(value), 'only ids');
+    return Record(record.session, field.desc.relation, value);
+  }
+  else if (field.cls === 'group') {
+    assert(_.isArray(value) && _.every(value, _.isNumber), 'only ids');
+    return Group(record.session, field.desc.relation, record, field.name)
+      .then((group) => {
+        group.init(value);
+        return group;
+      });
+  }
+  else {
+    throw new Error('bad type value');
+  }
+}
 Record.prototype.get = function (name, options) {
   dRec('%s: get', this.model.name);
-  var names;
   var obj;
   if (_.isUndefined(name)) {
     obj = true;
@@ -212,6 +125,7 @@ Record.prototype.get = function (name, options) {
   else {
     options = options || {};
   }
+  var names;
   if (obj) {
     names = _.keys(this.attrs);
   }
@@ -225,8 +139,10 @@ Record.prototype.get = function (name, options) {
     else {
       throw new Error('calling get with strange attributes');
     }
-    assert(this.id < 0 || this.readFields['*'] || _.every(names, (name) =>
-      this.readFields[name] === true), 'get unread fields');
+    assert(_.every(_.map(names, (name) => this.model.fields[name])),
+      'getting bad fields');
+    assert(this.readFields['*'] || _.every(names, (name) => this.readFields[
+      name] === true), 'getting unread fields');
   }
   assert(!_.includes(names, 'id'), 'can not get id');
   assert(_.isEmpty(_.omit(options, ['rpc', 'oc', 'inst', 'parent'])),
@@ -277,6 +193,37 @@ Record.prototype.get = function (name, options) {
     return res;
   }
 };
+
+function deflat(obj) {
+  var res = {};
+  _.each(_.keys(obj), (k) => {
+    var i = k.indexOf('.');
+    if (i >= 0) {
+      var key = k.substr(0, i);
+      var sub = k.substr(i + 1);
+      if (!res[key]) {
+        res[key] = {};
+      }
+      res[key][sub] = obj[k];
+      delete obj[k];
+    }
+  });
+  if (_.isEmpty(res)) {
+    return obj;
+  }
+  else {
+    _.each(_.keys(obj), (k) => {
+      if (res[k]) {
+        res[k].id = obj[k];
+        delete obj[k];
+      }
+    });
+    res = _.mapValues(res, (v) => {
+      return deflat(v);
+    });
+    return _.assign(obj, res);
+  }
+}
 Record.prototype.set = function (name, value, options) {
   dRec('%s: set', this.model.name);
   var values;
@@ -290,16 +237,21 @@ Record.prototype.set = function (name, value, options) {
   }
   options = options || {};
   assert(_.isUndefined(values.id), 'can not set id');
-  assert(_.isEmpty(_.omit(options, ['emit', 'sync', 'touch', 'oc'])),
+  assert(_.isEmpty(_.omit(options, ['event', 'sync', 'touch', 'oc'])),
     'unknown options');
   _.defaults(options, {
-    emit: true,
+    event: true,
     sync: true,
     touch: true,
     oc: false,
   });
   var changes = {};
-  var l = _.map(deflat(values), (v, k) => ({
+  values = deflat(values);
+  assert(_.every(_.map(values, (v, k) => this.model.fields[k])),
+    'setting bad fields');
+  assert(this.readFields['*'] || _.every(_.map(values, (v, k) => this.readFields[
+    k] === true)), 'setting unread fields');
+  var l = _.map(values, (v, k) => ({
     name: k,
     field: this.model.fields[k],
     value: this.model.fields[k].set(v, _.assign({
@@ -319,7 +271,7 @@ Record.prototype.set = function (name, value, options) {
     if (options.touch) {
       _.assign(this.changes, changes);
     }
-    if (options.emit) {
+    if (options.event) {
       this.emit('change');
       _.each(changes, (v, k) => {
         this.emit('change:' + k, this.attrs[k], v);
@@ -335,6 +287,18 @@ Record.prototype.set = function (name, value, options) {
     return Promise.resolve(this);
   }
 };
+
+function flatten(obj, paths) {
+  var values = _.map(paths, (path) => _.reduce(path.split('.'), (value, sub) => {
+    if (value) {
+      return value[sub];
+    }
+    else {
+      return value;
+    }
+  }, obj));
+  return _.zipObject(paths, values);
+}
 Record.prototype.onChange = function (names) {
   dRec('%s: onChange %s', this.model.name, names.join(','));
   var paths = _.uniq(_.flatten(_.map(names, (name) => this.model.fields[name]
@@ -351,7 +315,7 @@ Record.prototype.onChange = function (names) {
       .then((results) => Promise.all(_.map(results, (result) => this.set(
           result, {
             touch: true,
-            emit: true,
+            event: true,
             sync: false,
             oc: true,
           })))
@@ -389,7 +353,7 @@ Record.prototype.onChangeWith = function (names) {
       ], this.getContext())
       .then((result) => this.set(result, {
           touch: true,
-          emit: true,
+          event: true,
           sync: false,
           oc: true,
         })
@@ -403,7 +367,7 @@ Record.prototype.onChangeWith = function (names) {
                 '_' + fieldName, [values], this.getContext())
               .then((result) => this.set(result, {
                 touch: true,
-                emit: true,
+                event: true,
                 sync: false,
                 oc: true,
               }));
@@ -474,21 +438,68 @@ Record.prototype.toJSON = function (depth, level, parents) {
     id: this.id
   }, _.zipObject(_.map(l, 'name'), _.map(l, 'value')));
 };
+
+function parseReadParam(model, name) {
+  var all = _.keys(model.fields);
+  var eager = _.map(_.filter(model.fields, (field) => field.desc.loading ===
+    'eager'), 'name');
+  if (name) {
+    var names;
+    if (_.isString(name)) {
+      if (name === '*') {
+        return null;
+      }
+      else {
+        names = [name];
+      }
+    }
+    else if (_.isArray(name)) {
+      names = name;
+    }
+    else {
+      throw new Error('bad read param');
+    }
+    var excludes = _.map(_.filter(names, (n) => n.startsWith('!')), (n) => n.substr(
+      1));
+    if (_.isEmpty(excludes)) {
+      return _.uniq(names.concat(eager));
+    }
+    else {
+      return _.difference(all, excludes);
+    }
+  }
+  else {
+    return eager;
+  }
+}
+
+function afterRead(names, result) {
+  this.changes = {};
+  this.attrs = {};
+  this.readFields = names ? _.mapValues(result, () => true) : {
+    '*': true
+  };
+  delete result.id;
+  return this.set(result, {
+      touch: false,
+      event: true,
+      sync: false,
+    })
+    .then(() => {
+      this.readPromise = true;
+    });
+}
 Record.prototype.read = function (name) {
   dRec('%s: read', this.model.name);
   assert(this.id > 0, 'can not read non registered records');
-  if (!name) {
-    if (this.readPromise === true) {
-      return Promise.resolve(true);
-    }
-    else if (utils.isPromise(this.readPromise)) {
-      return this.readPromise;
-    }
+  assert(!this.changed(), 'can not read changed records');
+  if (utils.isPromise(this.readPromise)) {
+    return this.readPromise;
   }
-  var names = parseReadParam(this.model, name);
   var args = [
     [this.id]
   ];
+  var names = parseReadParam(this.model, name);
   if (names) {
     args.push(names);
   }
@@ -497,24 +508,12 @@ Record.prototype.read = function (name) {
     .then(
       (results) => {
         var result = results[0];
-        afterRead.call(this, name, result);
-        delete result.id;
-        if (!name) {
-          this.readPromise = true;
-        }
-        return this.set(result, {
-          touch: false,
-          emit: true,
-          sync: false,
-        });
-      }, () => {
-        if (!name) {
-          this.resetReadPromise();
-        }
+        return afterRead.call(this, names, result);
+      }, (err) => {
+        this.readPromise = false;
+        return Promise.reject(err);
       });
-  if (!name) {
-    this.readPromise = promise;
-  }
+  this.readPromise = promise;
   return promise;
 };
 Record.prototype.write = function () {
@@ -528,43 +527,42 @@ Record.prototype.write = function () {
       inst: false
     }))
   ];
-  var unlock = this.resetWritePromise.bind(this);
   this.writePromise = this.session.rpc('model.' + this.model.name + '.' +
       methods.modelWrite, args, this.getContext())
     .then(() => {
-      this.changes = {};
-      this.emit('write');
-      unlock();
+      resetAttrs.call(this);
+      this.writePromise = true;
       return this.read();
-    }, unlock);
+    }, (err) => {
+      this.writePromise = false;
+      return Promise.reject(err);
+    });
   return this.writePromise;
 };
 Record.prototype.create = function () {
   dRec('%s: create', this.model.name);
   assert(!utils.isPromise(this.writePromise), 'concurrent request');
   assert(this.id < 0, 'can only create non registered record');
-  var required = _.map(_.filter(_.toPairs(this.model.fields), (pair) => pair[
-    1].desc.required), (pair) => pair[0]);
   var names = _.keys(this.changes);
   var obj = _.zipObject(names, this.get(names, {
     rpc: true,
     inst: false
   }));
-  var missing = _.filter(required, (fname) => _.isUndefined(obj[fname]));
-  assert(_.isEmpty(missing), 'required attrs: ' + missing);
-  var unlock = this.resetWritePromise.bind(this);
   this.writePromise = this.session.rpc('model.' + this.model.name + '.' +
       methods.modelCreate, [
         [obj]
       ], this.getContext())
     .then((ids) => {
-      this.changes = {};
       var old = this.id;
       this.id = ids[0];
+      resetAttrs.call(this);
+      this.writePromise = true;
       this.emit('mutate', old, this.id);
-      unlock();
       return this.read();
-    }, unlock);
+    }, (err) => {
+      this.writePromise = false;
+      return Promise.reject(err);
+    });
   return this.writePromise;
 };
 Record.prototype.save = function () {
@@ -641,9 +639,13 @@ Group.prototype.init = function (ids) {
       this);
   });
 };
+Group.prototype.get = function () {
+  dGrp('%s: set', this.model.name);
+  return this.map((rec) => rec.get.apply(rec, arguments));
+};
 Group.prototype.set = function () {
   dGrp('%s: set', this.model.name);
-  return Promise.all(this.map((rec) => rec.set.apply(rec, arguments)));
+  return this.map((rec) => rec.set.apply(rec, arguments));
 };
 Group.prototype.toJSON = function (depth, level, parents) {
   dGrp('%s: toJSON', this.model.name);
@@ -654,21 +656,15 @@ Group.prototype.toJSON = function (depth, level, parents) {
 };
 Group.prototype.read = function (name) {
   dGrp('%s: read', this.model.name);
-  assert(!this.some((rec) => rec.id < 0),
+  assert(this.every((rec) => rec.id > 0),
     'can not read non registered records');
-  var started, starting;
-  if (!name) {
-    started = this.filter((rec) => utils.isPromise(rec.readPromise));
-    starting = this.filter((rec) => !utils.isPromise(rec.readPromise));
-  }
-  else {
-    started = [];
-    starting = this.records;
-  }
-  var names = parseReadParam(this.model, name);
+  assert(this.every((rec) => !rec.changed()), 'can not read changed record');
+  var started = this.filter((rec) => utils.isPromise(rec.readPromise));
+  var starting = this.filter((rec) => !utils.isPromise(rec.readPromise));
   var args = [
-    _.map(starting, (rec) => rec.id)
+    _.map(starting, 'id')
   ];
+  var names = parseReadParam(this.model, name);
   if (names) {
     args.push(names);
   }
@@ -678,25 +674,17 @@ Group.prototype.read = function (name) {
       var rec = _.find(starting, {
         id: result.id
       });
-      afterRead.call(rec, name, result);
-      delete result.id;
-      return rec.set(result, {
-          touch: false,
-          emit: true,
-          sync: false,
-        })
-        .then(() => {
-          if (!name) {
-            rec.readPromise = true;
-          }
-        });
-    })));
-  if (!name) {
-    _.each(starting, (rec) => {
-      rec.readPromise = promise;
+      return afterRead.call(rec, names, result);
+    })), (err) => {
+      _.each(starting, (rec) => {
+        rec.readPromise = false;
+      });
+      return Promise.reject(err);
     });
-  }
-  var promises = _.map(started, (rec) => rec.readPromise);
+  _.each(starting, (rec) => {
+    rec.readPromise = promise;
+  });
+  var promises = _.map(started, 'readPromise');
   promises.push(promise);
   return Promise.all(promises);
 };
@@ -714,7 +702,8 @@ Group.search = function (session, modelName, desc, context) {
       }));
 };
 Group.group = function (session, iterable) {
-  var model = iterable[0].model;
+  var model = _.first(iterable)
+    .model;
   var modelName = model.name;
   dGrp('%s: group', modelName);
   assert(!_.some(iterable, (rec) => !(rec instanceof Record) || rec.model.name !==

--- a/lib/index.js
+++ b/lib/index.js
@@ -141,10 +141,10 @@ Record.prototype.get = function (name, options) {
     }
     var notField = _.filter(names, (name) => _.isUndefined(this.model.fields[
       name]));
-    assert(_.isEmpty(notField), 'getting bad fields', notField);
+    assert(_.isEmpty(notField), 'getting bad fields' + notField);
     if (!this.readFields['*']) {
       var notRead = _.filter(names, (name) => this.readFields[name] !== true);
-      assert(_.isEmpty(notRead), 'getting unread fields', notRead);
+      assert(_.isEmpty(notRead), 'getting unread fields' + notRead);
     }
   }
   assert(!_.includes(names, 'id'), 'can not get id');
@@ -250,11 +250,13 @@ Record.prototype.set = function (name, value, options) {
   });
   var changes = {};
   values = deflat(values);
-  var notField = _.filter(values, (v, k) => _.isUndefined(this.model.fields[k]));
-  assert(_.isEmpty(notField), 'setting bad fields: ', notField);
+  var notField = _.keys(_.pickBy(values, (v, k) => _.isUndefined(this.model.fields[
+    k])));
+  assert(_.isEmpty(notField), 'setting bad fields: ' + notField);
   if (!this.readFields['*']) {
-    var notRead = _.filter(values, (v, k) => this.readFields[k] !== true);
-    assert(_.isEmpty(notRead), 'setting bad fields: ', notRead);
+    var notRead = _.keys(_.pickBy(values, (v, k) => this.readFields[k] !==
+      true));
+    assert(_.isEmpty(notRead), 'setting unread fields: ' + notRead);
   }
   var l = _.map(values, (v, k) => ({
     name: k,

--- a/tests/.data.js
+++ b/tests/.data.js
@@ -1,6 +1,6 @@
 exports.server = 'http://localhost:8000';
-exports.database = 'tryton';
-exports.username = 'admin';
+exports.database = process.env.TRYTON_MODEL_TEST_DB || 'tryton';
+exports.username = process.env.TRYTON_MODEL_TEST_USER || 'admin';
 exports.parameters = {
-  password: 'admin'
+  password: process.env.TRYTON_MODEL_TEST_PWD || 'admin'
 };

--- a/tests/dt.js
+++ b/tests/dt.js
@@ -1,11 +1,11 @@
-var t = require('tap');
-var co = require('co');
-var Session = require('tryton-session');
-var model = require('..');
-var data = require('./.data');
+const t = require('tap');
+const co = require('co');
+const Session = require('tryton-session');
+const model = require('..');
+const data = require('./.data');
 //
 model.init(Session);
-var session = new Session(data.server, data.database);
+const session = new Session(data.server, data.database);
 
 function start() {
   return session.start(data.username, data.parameters);
@@ -13,13 +13,13 @@ function start() {
 
 function test() {
   return co(function* () {
-    var group = yield model.Group.search(session, 'ir.cron', {});
-    var rec = group.first();
+    const group = yield model.Group.search(session, 'ir.cron', {});
+    const rec = group.first();
     if (!rec) {
       return;
     }
     yield rec.read();
-    var dt = rec.get('next_call', {
+    const dt = rec.get('next_call', {
       inst: false
     });
     t.match(dt, /\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d/);

--- a/tests/group.js
+++ b/tests/group.js
@@ -1,13 +1,13 @@
-var t = require('tap');
-var _ = require('lodash');
-var co = require('co');
-var Session = require('tryton-session');
-var model = require('..');
-var data = require('./.data');
+const t = require('tap');
+const _ = require('lodash');
+const co = require('co');
+const Session = require('tryton-session');
+const model = require('..');
+const data = require('./.data');
 //
 model.init(Session);
-var session = new Session(data.server, data.database);
-var users;
+const session = new Session(data.server, data.database);
+let users;
 
 function start() {
   return session.start(data.username, data.parameters);
@@ -28,14 +28,25 @@ function search() {
 function read() {
   return co(function* () {
     yield users.read(['name', 'login']);
-    var names = users.map((user) => user.get('name', {
+    const names = users.map((user) => user.get('name', {
       inst: false
     }));
     _.each(names, (name) => t.isa(name, 'string'));
-    var logins = users.map((user) => user.get('login', {
+    const myUsers = model.Group.group(session, users.map());
+    const logins = myUsers.get('login', {
       inst: false
-    }));
+    });
     _.each(logins, (login) => t.isa(login, 'string'));
+  });
+}
+
+function readCrash() {
+  return co(function* () {
+    const bak = session.token;
+    session.token = '123';
+    yield users.read()
+      .then(() => t.ok(false), (err) => t.type(err, 'object'));
+    session.token = bak;
   });
 }
 
@@ -45,5 +56,6 @@ function stop() {
 t.test(start)
   .then(search)
   .then(read)
+  .then(readCrash)
   .then(stop)
   .catch(t.threw);

--- a/tests/group.js
+++ b/tests/group.js
@@ -50,6 +50,24 @@ function readCrash() {
   });
 }
 
+function getNotField() {
+  return co(function* () {
+    yield users.read();
+    t.throws(users.get.bind(users, 'hello', {
+      inst: false
+    }));
+  });
+}
+
+function getNotRead() {
+  return co(function* () {
+    yield users.read();
+    t.throws(users.get.bind(users, 'groups', {
+      inst: false
+    }));
+  });
+}
+
 function stop() {
   return session.stop();
 }
@@ -57,5 +75,7 @@ t.test(start)
   .then(search)
   .then(read)
   .then(readCrash)
+  .then(getNotField)
+  .then(getNotRead)
   .then(stop)
   .catch(t.threw);

--- a/tests/record.js
+++ b/tests/record.js
@@ -46,6 +46,24 @@ function create2ManyOnTheFly() {
   });
 }
 
+function getNotField() {
+  return co(function* () {
+    yield user.read();
+    t.throws(user.get.bind(user, 'hello', {
+      inst: false
+    }));
+  });
+}
+
+function getNotRead() {
+  return co(function* () {
+    yield user.read();
+    t.throws(user.get.bind(user, 'groups', {
+      inst: false
+    }));
+  });
+}
+
 function remove2ManyItem() {
   return co(function* () {
     yield user.read('groups');
@@ -85,6 +103,8 @@ t.test(start)
   .then(create)
   .then(missingData)
   .then(create2ManyOnTheFly)
+  .then(getNotField)
+  .then(getNotRead)
   .then(remove2ManyItem)
   .then(force2ManyList)
   .then(readCrash)

--- a/tests/record.js
+++ b/tests/record.js
@@ -1,14 +1,13 @@
-var _ = require('lodash');
-var t = require('tap');
-var co = require('co');
-var Session = require('tryton-session');
-var model = require('..');
-var data = require('./.data');
+const t = require('tap');
+const co = require('co');
+const Session = require('tryton-session');
+const model = require('..');
+const data = require('./.data');
 //
 model.init(Session);
-var session = new Session(data.server, data.database);
-var login = '' + Math.floor(Math.random() * 1000000);
-var user;
+const session = new Session(data.server, data.database);
+const login = '' + Math.floor(Math.random() * 1000000);
+let user;
 
 function start() {
   return session.start(data.username, data.parameters);
@@ -21,60 +20,61 @@ function create() {
   });
 }
 
-function setLogin() {
-  return user.set('login', 'john');
-}
-
-function saveKO() {
-  t.throws(user.save);
-}
-
-function setDefault() {
-  return user.setDefault();
-}
-
-function set() {
-  return user.set({
-    name: 'Test User',
-    login: login,
-    password: login,
-    groups: [1, {
-      name: login
-    }]
-  });
-}
-
-function removeGroups() {
-  var groups = user.get('groups', {
-    inst: false
-  });
-  t.ok(_.isArray(groups));
-  t.equal(groups.length, 2);
-  t.ok(_.includes(groups, 1));
-  return user.set('groups', '-1-');
-}
-
-function forceGroups() {
-  var groups = user.get('groups', {
-    inst: false
-  });
-  t.equal(groups.length, 1);
-  return user.set('groups', [1]);
-}
-
-function checkGroups() {
-  var groups = user.get('groups', {
-    inst: false
-  });
-  t.equal(groups.length, 1);
-  t.equal(groups[0], 1);
-}
-
-function save() {
+function missingData() {
   return co(function* () {
+    yield user.set('login', 'john');
+    yield user.save()
+      .then(() => t.ok(false), (err) => t.type(err, 'object'));
+  });
+}
+
+function create2ManyOnTheFly() {
+  return co(function* () {
+    yield user.setDefault();
+    yield user.set({
+      name: 'Test User',
+      login: login,
+      password: login,
+      groups: [1, {
+        name: login
+      }]
+    });
     yield user.save();
-    t.ok(user.id);
-    t.isa(user.id, 'number');
+    yield user.read('groups');
+    const groups = yield user.get('groups');
+    t.equal(groups.size(), 2);
+  });
+}
+
+function remove2ManyItem() {
+  return co(function* () {
+    yield user.read('groups');
+    yield user.set('groups', '-1-');
+    yield user.save();
+    yield user.read('groups');
+    const groups = yield user.get('groups');
+    t.equal(groups.size(), 1);
+  });
+}
+
+function force2ManyList() {
+  return co(function* () {
+    yield user.read('groups');
+    yield user.set('groups', [1]);
+    yield user.save();
+    yield user.read('groups');
+    const groups = yield user.get('groups');
+    t.equal(groups.size(), 1);
+  });
+}
+
+function readCrash() {
+  return co(function* () {
+    const bak = session.token;
+    session.token = '123';
+    yield user.read()
+      .then(() => t.ok(false), (err) => t.type(err, 'object'));
+    session.token = bak;
   });
 }
 
@@ -83,15 +83,10 @@ function stop() {
 }
 t.test(start)
   .then(create)
-  .then(setLogin)
-  .then(saveKO)
-  .then(setDefault)
-  .then(set)
-  .then(save)
-  .then(removeGroups)
-  .then(save)
-  .then(forceGroups)
-  .then(save)
-  .then(checkGroups)
+  .then(missingData)
+  .then(create2ManyOnTheFly)
+  .then(remove2ManyItem)
+  .then(force2ManyList)
+  .then(readCrash)
   .then(stop)
   .catch(t.threw);

--- a/tests/session.js
+++ b/tests/session.js
@@ -1,13 +1,13 @@
-var t = require('tap');
-var _ = require('lodash');
-var co = require('co');
-var Session = require('tryton-session');
-var model = require('..');
-var data = require('./.data');
+const t = require('tap');
+const _ = require('lodash');
+const co = require('co');
+const Session = require('tryton-session');
+const model = require('..');
+const data = require('./.data');
 //
 model.init(Session);
-var session = new Session(data.server, data.database);
-var cache;
+let session = new Session(data.server, data.database);
+let cache;
 
 function start() {
   return session.start(data.username, data.parameters);
@@ -16,7 +16,7 @@ function start() {
 function access() {
   t.ok(_.isPlainObject(session.access));
   t.ok(session.access['ir.model']);
-  var sample = _.sample(session.access);
+  const sample = _.sample(session.access);
   t.ok(_.isPlainObject(sample));
   t.ok(!_.isNil(sample.create));
   t.ok(!_.isNil(sample.read));
@@ -27,7 +27,7 @@ function access() {
 function check() {
   t.ok(_.isPlainObject(session.models));
   t.ok(session.models['ir.model']);
-  var m = session.models['ir.model'];
+  const m = session.models['ir.model'];
   t.ok(m instanceof model.Model);
 }
 


### PR DESCRIPTION
Fix #5783
read eager by default
more read parameters (*, read eagers even if we ask for one field)
no read on changed record
no get/set on unread attributes
same behaviour for readPromise and writePromise
add get on group
unpublish internals from prototype